### PR TITLE
Make class colors work for all classes with the same profile

### DIFF
--- a/BasicMinimap.lua
+++ b/BasicMinimap.lua
@@ -37,6 +37,18 @@ function frame:HideButtons(_, _, name)
 	ldbi:ShowOnEnter(name, true)
 end
 
+function frame:ClassColor()
+	local _, class = UnitClass("player")
+	color = CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[class] or RAID_CLASS_COLORS[class]
+	alpha = 1
+	return {color.r, color.g, color.b, alpha}
+end
+
+function frame:UpdateBorder()
+	color = self.db.profile.colorBorder == nil and self:ClassColor() or self.db.profile.colorBorder
+	self.backdrop:SetColorTexture(unpack(color))
+end
+
 -- Init
 function frame:ADDON_LOADED(event, addon)
 	if addon == "BasicMinimap" then
@@ -63,7 +75,7 @@ function frame:ADDON_LOADED(event, addon)
 				outline = "OUTLINE",
 				monochrome = false,
 				font = media:GetDefault("font"),
-				colorBorder = {0,0.6,0,1},
+				colorBorder = nil,
 				calendarBtn = "RightButton",
 				trackingBtn = "MiddleButton",
 				missionsBtn = "None",
@@ -103,14 +115,14 @@ function frame:PLAYER_LOGIN(event)
 
 	-- Backdrop, creating the border cleanly
 	local backdrop = self.CreateTexture(Minimap, nil, "BACKGROUND")
+	frame.backdrop = backdrop
 	backdrop:SetPoint("CENTER", Minimap, "CENTER")
 	backdrop:SetSize(self.db.profile.size + self.db.profile.borderSize, self.db.profile.size + self.db.profile.borderSize)
-	backdrop:SetColorTexture(unpack(self.db.profile.colorBorder))
+	self:UpdateBorder()
 	local mask = self:CreateMaskTexture()
 	mask:SetAllPoints(backdrop)
 	mask:SetParent(Minimap)
 	backdrop:AddMaskTexture(mask)
-	frame.backdrop = backdrop
 	frame.mask = mask
 
 	self.ClearAllPoints(Minimap)

--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -49,21 +49,18 @@ local acOptions = {
 				colorBorder = {
 					name = L.borderColor,
 					order = 1, type = "color", hasAlpha = true,
-					get = function() return unpack(map.db.profile.colorBorder) end,
+					get = function() return unpack(map.db.profile.colorBorder == nil and map:ClassColor() or map.db.profile.colorBorder) end,
 					set = function(_, r, g, b, a)
 						map.db.profile.colorBorder = {r, g, b, a}
-						map.backdrop:SetColorTexture(r, g, b, a)
+						map:UpdateBorder()
 					end,
 				},
 				classcolor = {
 					name = L.CLASSCOLORED,
 					order = 2, type = "execute",
 					func = function()
-						local _, class = UnitClass("player")
-						local color = CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[class] or RAID_CLASS_COLORS[class]
-						local a = map.db.profile.colorBorder[4]
-						map.db.profile.colorBorder = {color.r, color.g, color.b, a}
-						map.backdrop:SetColorTexture(color.r, color.g, color.b, a)
+						map.db.profile.colorBorder = nil
+						map:UpdateBorder()
 					end,
 				},
 				borderSize = {


### PR DESCRIPTION
With all of the alts that I play, I try to keep my addons configured as generically as possible so that default profiles work for the vast majority of cases. I appreciate that it is technically possible to have class colored border for each class, but that means I have to open the settings and switch profiles and hit the class color button for every alt. On the one hand, that's not such a great burden individually, but it's one more thing I have to do to get my UI back when I log a toon I haven't played in awhile, and this is just one of many addons, all of which are always subtly in flux.

This is all part of my argument for why the I believe profile support is not the ideal solution for this problem.

My proposition is to make it so that clicking the Class Colored button sets the value of `map.db.profile.colorBorder` to `nil` (or some other sentinel value). Then in the getter function for `colorBorder`, if `map.db.profile.colorBorder` is `nil`, return the class color of the player.

That way, it is trivial to keep a default profile that works for all toons, and still matches the UI to my class.